### PR TITLE
Add quotation marks to pip install instruction

### DIFF
--- a/src/sqlfmt_web/assets/greeting.md
+++ b/src/sqlfmt_web/assets/greeting.md
@@ -11,7 +11,7 @@ sqlfmt formats your dbt SQL files so you don't have to. It is similar in nature 
 
 [Read the docs](https://docs.sqlfmt.com/category/getting-started) to get started.
 
-**tl;dr: `pip install shandy-sqlfmt[jinjafmt]`**
+**tl;dr: `pip install "shandy-sqlfmt[jinjafmt]"`**
 
 ## Or you can try it out here
 

--- a/src/sqlfmt_web/assets/greeting.md
+++ b/src/sqlfmt_web/assets/greeting.md
@@ -11,7 +11,7 @@ sqlfmt formats your dbt SQL files so you don't have to. It is similar in nature 
 
 [Read the docs](https://docs.sqlfmt.com/category/getting-started) to get started.
 
-**tl;dr: `pip install "shandy-sqlfmt[jinjafmt]"`**
+**tl;dr: `pip install 'shandy-sqlfmt[jinjafmt]'`**
 
 ## Or you can try it out here
 


### PR DESCRIPTION
A figure explains best why this change was necessary:
<img width="509" alt="image" src="https://user-images.githubusercontent.com/2721423/210582780-619706b5-24c7-4c06-aa10-40137b2bd8dd.png">


This is in zsh on Mac OS. 